### PR TITLE
Introduce pepper option

### DIFF
--- a/lib/sorcery/crypto_providers/bcrypt.rb
+++ b/lib/sorcery/crypto_providers/bcrypt.rb
@@ -41,8 +41,8 @@ module Sorcery
     class BCrypt
       class << self
         # Setting the option :pepper allows users to append an app-specific secret token.
-        # basically equivalent to :salt_join_token option, but have different name to ensure
-        # backward compatibility in generating/matching passwards.
+        # Basically it's equivalent to :salt_join_token option, but have a different name to ensure
+        # backward compatibility in generating/matching passwords.
         attr_accessor :pepper
         # This is the :cost option for the BCrpyt library.
         # The higher the cost the more secure it is and the longer is take the generate a hash. By default this is 10.

--- a/lib/sorcery/crypto_providers/bcrypt.rb
+++ b/lib/sorcery/crypto_providers/bcrypt.rb
@@ -40,6 +40,10 @@ module Sorcery
     # You are good to go!
     class BCrypt
       class << self
+        # Setting the option :pepper allows users to append an app-specific secret token.
+        # basically equivalent to :salt_join_token option, but have different name to ensure
+        # backward compatibility in generating/matching passwards.
+        attr_accessor :pepper
         # This is the :cost option for the BCrpyt library.
         # The higher the cost the more secure it is and the longer is take the generate a hash. By default this is 10.
         # Set this to whatever you want, play around with it to get that perfect balance between
@@ -77,12 +81,13 @@ module Sorcery
 
         def reset!
           @cost = 10
+          @pepper = ''
         end
 
         private
 
         def join_tokens(tokens)
-          tokens.flatten.join
+          tokens.flatten.join.concat(pepper.to_s) # make sure to add pepper in case tokens have only one element
         end
 
         def new_from_hash(hash)

--- a/lib/sorcery/model.rb
+++ b/lib/sorcery/model.rb
@@ -142,6 +142,7 @@ module Sorcery
       def set_encryption_attributes
         @sorcery_config.encryption_provider.stretches = @sorcery_config.stretches if @sorcery_config.encryption_provider.respond_to?(:stretches) && @sorcery_config.stretches
         @sorcery_config.encryption_provider.join_token = @sorcery_config.salt_join_token if @sorcery_config.encryption_provider.respond_to?(:join_token) && @sorcery_config.salt_join_token
+        @sorcery_config.encryption_provider.pepper = @sorcery_config.pepper if @sorcery_config.encryption_provider.respond_to?(:pepper) && @sorcery_config.pepper
       end
 
       def add_config_inheritance

--- a/lib/sorcery/model/config.rb
+++ b/lib/sorcery/model/config.rb
@@ -12,11 +12,11 @@ module Sorcery
       attr_accessor :downcase_username_before_authenticating
       # change default crypted_password attribute.
       attr_accessor :crypted_password_attribute_name
-      # application-specific secret token that are joined with the password and its salt.
+      # application-specific secret token that is joined with the password and its salt.
       # Currently available with BCrypt (default crypt provider) only.
       attr_accessor :pepper
       # what pattern to use to join the password with the salt
-      # APPLICABLE TO MD5, SHA1, SHA256, SHA512. Other crypt providers (incl. BCrypt) ignores this parameter.
+      # APPLICABLE TO MD5, SHA1, SHA256, SHA512. Other crypt providers (incl. BCrypt) ignore this parameter.
       attr_accessor :salt_join_token
       # change default salt attribute.
       attr_accessor :salt_attribute_name

--- a/lib/sorcery/model/config.rb
+++ b/lib/sorcery/model/config.rb
@@ -12,7 +12,11 @@ module Sorcery
       attr_accessor :downcase_username_before_authenticating
       # change default crypted_password attribute.
       attr_accessor :crypted_password_attribute_name
+      # application-specific secret token that are joined with the password and its salt.
+      # Currently available with BCrypt (default crypt provider) only.
+      attr_accessor :pepper
       # what pattern to use to join the password with the salt
+      # APPLICABLE TO MD5, SHA1, SHA256, SHA512. Other crypt providers (incl. BCrypt) ignores this parameter.
       attr_accessor :salt_join_token
       # change default salt attribute.
       attr_accessor :salt_attribute_name
@@ -57,6 +61,7 @@ module Sorcery
           :@encryption_provider                  => CryptoProviders::BCrypt,
           :@custom_encryption_provider           => nil,
           :@encryption_key                       => nil,
+          :@pepper                               => '',
           :@salt_join_token                      => '',
           :@salt_attribute_name                  => :salt,
           :@stretches                            => nil,

--- a/spec/shared_examples/user_shared_examples.rb
+++ b/spec/shared_examples/user_shared_examples.rb
@@ -504,30 +504,28 @@ shared_examples_for 'rails_3_core_model' do
       expect(user.crypted_password).to eq Sorcery::CryptoProviders::SHA512.encrypt('secret', user.salt)
     end
 
-    context '' do
-      it 'if pepper is set uses it to encrypt' do
-        sorcery_model_property_set(:salt_attribute_name, :salt)
-        sorcery_model_property_set(:pepper, '++@^$')
-        sorcery_model_property_set(:encryption_algorithm, :bcrypt)
+    it 'if pepper is set uses it to encrypt' do
+      sorcery_model_property_set(:salt_attribute_name, :salt)
+      sorcery_model_property_set(:pepper, '++@^$')
+      sorcery_model_property_set(:encryption_algorithm, :bcrypt)
 
-        # password comparison is done using BCrypt::Password#==(raw_token), not String#==
-        bcrypt_password = BCrypt::Password.new(user.crypted_password)
-        allow(::BCrypt::Password).to receive(:create) do |token, cost:|
-          # need to use common BCrypt's salt when genarating BCrypt::Password objects
-          # so that any generated password hashes can be compared each other
-          ::BCrypt::Engine.hash_secret(token, bcrypt_password.salt)
-        end
-
-        expect(user.crypted_password).not_to eq Sorcery::CryptoProviders::BCrypt.encrypt('secret')
-
-        Sorcery::CryptoProviders::BCrypt.pepper = ''
-
-        expect(user.crypted_password).not_to eq Sorcery::CryptoProviders::BCrypt.encrypt('secret', user.salt)
-
-        Sorcery::CryptoProviders::BCrypt.pepper = User.sorcery_config.pepper
-
-        expect(user.crypted_password).to eq Sorcery::CryptoProviders::BCrypt.encrypt('secret', user.salt)
+      # password comparison is done using BCrypt::Password#==(raw_token), not String#==
+      bcrypt_password = BCrypt::Password.new(user.crypted_password)
+      allow(::BCrypt::Password).to receive(:create) do |token, cost:|
+        # need to use common BCrypt's salt when genarating BCrypt::Password objects
+        # so that any generated password hashes can be compared each other
+        ::BCrypt::Engine.hash_secret(token, bcrypt_password.salt)
       end
+
+      expect(user.crypted_password).not_to eq Sorcery::CryptoProviders::BCrypt.encrypt('secret')
+
+      Sorcery::CryptoProviders::BCrypt.pepper = ''
+
+      expect(user.crypted_password).not_to eq Sorcery::CryptoProviders::BCrypt.encrypt('secret', user.salt)
+
+      Sorcery::CryptoProviders::BCrypt.pepper = User.sorcery_config.pepper
+
+      expect(user.crypted_password).to eq Sorcery::CryptoProviders::BCrypt.encrypt('secret', user.salt)
     end
   end
 

--- a/spec/shared_examples/user_shared_examples.rb
+++ b/spec/shared_examples/user_shared_examples.rb
@@ -54,6 +54,13 @@ shared_examples_for 'rails_3_core_model' do
       expect(User.sorcery_config.custom_encryption_provider).to eq Array
     end
 
+    it "enables configuration option 'pepper'" do
+      pepper = '*$%&%*++'
+      sorcery_model_property_set(:pepper, pepper)
+
+      expect(User.sorcery_config.pepper).to eq pepper
+    end
+
     it "enables configuration option 'salt_join_token'" do
       salt_join_token = '--%%*&-'
       sorcery_model_property_set(:salt_join_token, salt_join_token)
@@ -459,6 +466,14 @@ shared_examples_for 'rails_3_core_model' do
       expect(User.encrypt(@text)).to eq Sorcery::CryptoProviders::SHA512.encrypt(@text)
     end
 
+    it 'if encryption algo is bcrypt it works' do
+      sorcery_model_property_set(:encryption_algorithm, :bcrypt)
+
+      # comparison is done using BCrypt::Password#==(raw_token), not by String#==
+      expect(User.encrypt(@text)).to be_an_instance_of BCrypt::Password
+      expect(User.encrypt(@text)).to eq @text
+    end
+
     it 'salt is random for each user and saved in db' do
       sorcery_model_property_set(:salt_attribute_name, :salt)
 
@@ -487,6 +502,32 @@ shared_examples_for 'rails_3_core_model' do
       Sorcery::CryptoProviders::SHA512.join_token = User.sorcery_config.salt_join_token
 
       expect(user.crypted_password).to eq Sorcery::CryptoProviders::SHA512.encrypt('secret', user.salt)
+    end
+
+    context '' do
+      it 'if pepper is set uses it to encrypt' do
+        sorcery_model_property_set(:salt_attribute_name, :salt)
+        sorcery_model_property_set(:pepper, '++@^$')
+        sorcery_model_property_set(:encryption_algorithm, :bcrypt)
+
+        # password comparison is done using BCrypt::Password#==(raw_token), not String#==
+        bcrypt_password = BCrypt::Password.new(user.crypted_password)
+        allow(::BCrypt::Password).to receive(:create) do |token, cost:|
+          # need to use common BCrypt's salt when genarating BCrypt::Password objects
+          # so that any generated password hashes can be compared each other
+          ::BCrypt::Engine.hash_secret(token, bcrypt_password.salt)
+        end
+
+        expect(user.crypted_password).not_to eq Sorcery::CryptoProviders::BCrypt.encrypt('secret')
+
+        Sorcery::CryptoProviders::BCrypt.pepper = ''
+
+        expect(user.crypted_password).not_to eq Sorcery::CryptoProviders::BCrypt.encrypt('secret', user.salt)
+
+        Sorcery::CryptoProviders::BCrypt.pepper = User.sorcery_config.pepper
+
+        expect(user.crypted_password).to eq Sorcery::CryptoProviders::BCrypt.encrypt('secret', user.salt)
+      end
     end
   end
 

--- a/spec/sorcery_crypto_providers_spec.rb
+++ b/spec/sorcery_crypto_providers_spec.rb
@@ -207,6 +207,36 @@ describe 'Crypto Providers wrappers' do
         expect(Sorcery::CryptoProviders::BCrypt.matches?(@digest, *@tokens)).to be true
       end
 
+      it 'matches? returns false when pepper is replaced with empty string' do
+        Sorcery::CryptoProviders::BCrypt.pepper = ''
+        expect(Sorcery::CryptoProviders::BCrypt.matches?(@digest, *@tokens)).to be false
+      end
+
+      it 'matches? returns false when no match' do
+        expect(Sorcery::CryptoProviders::BCrypt.matches?(@digest, 'a_random_incorrect_password')).to be false
+      end
+    end
+
+    context "when pepper is an empty string (default)" do
+      before(:each) do
+        Sorcery::CryptoProviders::BCrypt.pepper = ''
+        @digest = Sorcery::CryptoProviders::BCrypt.encrypt(@tokens) # a BCrypt::Password object
+      end
+
+      # make sure the default pepper '' does nothing
+      it 'matches token encrypted with salt only (without pepper)' do
+        expect(@digest).to eq @tokens.flatten.join # keep consistency with the older versions of #join_token
+      end
+
+      it 'matches? returns true when matches' do
+        expect(Sorcery::CryptoProviders::BCrypt.matches?(@digest, *@tokens)).to be true
+      end
+
+      it 'matches? returns false when pepper has changed' do
+        Sorcery::CryptoProviders::BCrypt.pepper = 'a new pepper'
+        expect(Sorcery::CryptoProviders::BCrypt.matches?(@digest, *@tokens)).to be false
+      end
+
       it 'matches? returns false when no match' do
         expect(Sorcery::CryptoProviders::BCrypt.matches?(@digest, 'a_random_incorrect_password')).to be false
       end


### PR DESCRIPTION
PR for testing purpose (with Travis)

```
config option 'salt_join_token' option has been ignored when BCrypot is
chosen as crypto-provider (default).
This patch introduces its alternative option that allows to add
app-specific secret token in using BCrypt.
To ensure compatibility, this change only takes place when the new
option 'pepper' is provided, and does NOT affect on those who have
already set salt_join_token.
```